### PR TITLE
fix(gui): make auto-updater repository targets dynamic by reading from package.json

### DIFF
--- a/src/gui.js
+++ b/src/gui.js
@@ -26,12 +26,29 @@ const net = require("net");
 
 app.commandLine.appendSwitch("disable-renderer-backgrounding");
 
-// global varibles
-autoUpdater.setFeedURL({
-  provider: "github",
-  owner: "TheYogMehta",
-  repo: "StrawVerse",
-});
+// Load package.json config dynamically for the auto-updater to support fork updates
+try {
+  const pkg = require("./package.json");
+  if (pkg.build && pkg.build.publish) {
+    autoUpdater.setFeedURL({
+      provider: "github",
+      owner: pkg.build.publish.owner,
+      repo: pkg.build.publish.repo,
+    });
+  } else {
+    autoUpdater.setFeedURL({
+      provider: "github",
+      owner: "TheYogMehta",
+      repo: "StrawVerse",
+    });
+  }
+} catch (err) {
+  autoUpdater.setFeedURL({
+    provider: "github",
+    owner: "TheYogMehta",
+    repo: "StrawVerse",
+  });
+}
 
 //  functions
 const { logger } = require("./backend/utils/AppLogger");


### PR DESCRIPTION
### 📝 Description
This PR makes the Electron auto-updater repository feed targets dynamic by reading the publish configuration directly from `package.json` at runtime, rather than hardcoding it to `TheYogMehta/StrawVerse`.

### ❓ Why is this needed?
Currently, the auto-updater is hardcoded to:
```javascript
autoUpdater.setFeedURL({
  provider: "github",
  owner: "TheYogMehta",
  repo: "StrawVerse",
});
